### PR TITLE
Add attribute #[\ReturnTypeWillChange] for PHP 8.1 compatibility

### DIFF
--- a/src/FixedSizeCollection.php
+++ b/src/FixedSizeCollection.php
@@ -127,6 +127,7 @@ class FixedSizeCollection implements IteratorAggregate
      *
      * @return Generator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         foreach ($this->pageList as $page) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -170,6 +170,7 @@ class Page implements IteratorAggregate
      *
      * @return Generator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $resourcesGetMethod = $this->pageStreamingDescriptor->getResourcesGetMethod();

--- a/src/PagedListResponse.php
+++ b/src/PagedListResponse.php
@@ -121,6 +121,7 @@ class PagedListResponse implements IteratorAggregate
      * @return Generator
      * @throws ValidationException
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         foreach ($this->iteratePages() as $page) {


### PR DESCRIPTION
Receiving this error message on PHP 8.1 for Page, PagedListResponse and FixedSizeCollection:

Error: [8192] Return type of Google\ApiCore\Page::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice